### PR TITLE
Automatically Refresh Token

### DIFF
--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -87,6 +87,7 @@ namespace Owin.Security.Providers.CanvasLMS
                 dynamic response = JsonConvert.DeserializeObject<dynamic>(text);
                 var accessToken = (string)response.access_token;
                 var refreshToken = (string)response.refresh_token;
+                var expiresIn = (int?)response.expires_in;
 
                 // Get the user info
                 var userInfoRequest = new HttpRequestMessage(HttpMethod.Get, Options.EndpointBase + Options.Endpoints.UserPath);
@@ -97,7 +98,7 @@ namespace Owin.Security.Providers.CanvasLMS
                 text = await userInfoResponse.Content.ReadAsStringAsync();
                 var user = JObject.Parse(text);
 
-                var context = new CanvasAuthenticatedContext(Context, user, accessToken, refreshToken)
+                var context = new CanvasAuthenticatedContext(Context, user, accessToken, refreshToken, expiresIn)
                 {
                     Identity = new ClaimsIdentity(
                         Options.AuthenticationType,

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -96,8 +96,8 @@ namespace Owin.Security.Providers.CanvasLMS
                 userInfoRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 var userInfoResponse = await _httpClient.SendAsync(userInfoRequest);
                 userInfoResponse.EnsureSuccessStatusCode();
-                text = await userInfoResponse.Content.ReadAsStringAsync();
-                var user = JObject.Parse(text);
+                var userInfoResponseContent = await userInfoResponse.Content.ReadAsStringAsync();
+                var user = JObject.Parse(userInfoResponseContent);
 
                 var context = new CanvasAuthenticatedContext(Context, user, accessToken, refreshToken, expiresIn)
                 {

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -62,7 +62,7 @@ namespace Owin.Security.Providers.CanvasLMS
                     return new AuthenticationTicket(null, properties);
                 }
 
-                var response = await RequestToken(code);
+                var response = await RequestToken("authorization_code", code, "code");
                 var accessToken = (string)response.access_token;
                 var refreshToken = (string)response.refresh_token;
                 var expiresIn = (int?)response.expires_in;
@@ -242,7 +242,7 @@ namespace Owin.Security.Providers.CanvasLMS
             return context.IsRequestCompleted;
         }
 
-        private async Task<object> RequestToken(string code)
+        private async Task<object> RequestToken(string grantType, string grantToken, string grantTokenParameterName = null)
         {
             var requestPrefix = Request.Scheme + "://" + Request.Host;
             var redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
@@ -250,8 +250,8 @@ namespace Owin.Security.Providers.CanvasLMS
             // Build up the body for the token request
             var body = new List<KeyValuePair<string, string>>
             {
-                new KeyValuePair<string, string>("code", code),
-                new KeyValuePair<string, string>("grant_type", "authorization_code"),
+                new KeyValuePair<string, string>(grantTokenParameterName ?? grantType, grantToken),
+                new KeyValuePair<string, string>("grant_type", grantType),
                 new KeyValuePair<string, string>("client_id", Options.ClientId),
                 new KeyValuePair<string, string>("redirect_uri", redirectUri)
             };

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -234,7 +234,7 @@ namespace Owin.Security.Providers.CanvasLMS
 
         private async Task<object> RequestToken(string grantType, string grantToken, string grantTokenParameterName = null)
         {
-            var requestPrefix = Request.Scheme + "://" + Request.Host;
+            var requestPrefix = Request.Scheme + Uri.SchemeDelimiter + Request.Host;
             var redirectUri = requestPrefix + Request.PathBase + Options.CallbackPath;
 
             // Build up the body for the token request

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -136,12 +136,12 @@ namespace Owin.Security.Providers.CanvasLMS
 
         private async Task<bool> RefreshAccessTokenAsync()
         {
-            var refreshToken = Context.Authentication.User?.FindFirst(Constants.CanvasRefreshToken)?.Value;
-            if (string.IsNullOrEmpty(refreshToken))
-                return false;
-
             var accessTokenExpiration = ParseExpiration();
             if (accessTokenExpiration > DateTimeOffset.Now.AddMinutes(1))
+                return false;
+
+            var refreshToken = Context.Authentication.User?.FindFirst(Constants.CanvasRefreshToken)?.Value;
+            if (string.IsNullOrEmpty(refreshToken))
                 return false;
 
             _logger.WriteInformation("Requesting new access token.");

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -112,6 +112,15 @@ namespace Owin.Security.Providers.CanvasLMS
                 {
                     context.Identity.AddClaim(new Claim(ClaimsIdentity.DefaultNameClaimType, context.Name, XmlSchemaString, Options.AuthenticationType));
                 }
+                if (!string.IsNullOrEmpty(context.AccessToken))
+                {
+                    context.Identity.AddClaim(new Claim(Constants.CanvasAccessToken, context.AccessToken));
+                }
+                if (!string.IsNullOrEmpty(context.RefreshToken))
+                {
+                    context.Identity.AddClaim(new Claim(Constants.CanvasRefreshToken, context.RefreshToken));
+                }
+
                 context.Properties = properties;
 
                 await Options.Provider.Authenticated(context);

--- a/src/Owin.Security.Providers.CanvasLMS/Constants.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/Constants.cs
@@ -1,7 +1,9 @@
 ﻿namespace Owin.Security.Providers.CanvasLMS
 {
-    internal static class Constants
+    public static class Constants
     {
         public const string DefaultAuthenticationType = "CanvasLMS";
+        public static readonly string CanvasAccessToken = "urn:canvas:access_token";
+        public static readonly string CanvasRefreshToken = "urn:canvas:refresh_token";
     }
 }

--- a/src/Owin.Security.Providers.CanvasLMS/Constants.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/Constants.cs
@@ -4,6 +4,7 @@
     {
         public const string DefaultAuthenticationType = "CanvasLMS";
         public static readonly string CanvasAccessToken = "urn:canvas:access_token";
+        public static readonly string CanvasAccessTokenExpiration = "urn:canvas:access_token_expiration";
         public static readonly string CanvasRefreshToken = "urn:canvas:refresh_token";
     }
 }

--- a/src/Owin.Security.Providers.CanvasLMS/Provider/CanvasAuthenticatedContext.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/Provider/CanvasAuthenticatedContext.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Security.Claims;
 using Microsoft.Owin;
 using Microsoft.Owin.Security;
@@ -20,10 +21,12 @@ namespace Owin.Security.Providers.CanvasLMS.Provider
         /// <param name="user">The Canvas user information</param>
         /// <param name="accessToken">Canvas Access token</param>
         /// <param name="refreshToken">Canvas Refresh token</param>
-        public CanvasAuthenticatedContext(IOwinContext context, JObject user, string accessToken, string refreshToken)
+        /// <param name="expiresIn">Seconds until the access token expires</param>
+        public CanvasAuthenticatedContext(IOwinContext context, JObject user, string accessToken, string refreshToken, int? expiresIn)
             : base(context)
         {
             AccessToken = accessToken;
+            AccessTokenExpiration = DateTimeOffset.Now.AddSeconds(expiresIn ?? 0);
             RefreshToken = refreshToken;
             User = user;
             Name = user.SelectToken("name").ToString();
@@ -52,6 +55,11 @@ namespace Owin.Security.Providers.CanvasLMS.Provider
         /// Gets the Canvas access token
         /// </summary>
         public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// Get the Canvas access token expiration time
+        /// </summary>
+        public DateTimeOffset AccessTokenExpiration { get; set; }
 
         /// <summary>
         /// Gets the Canvas refresh token


### PR DESCRIPTION
Props to @Steven-Pingel for ideas on the general approach:
1. On auth, capture `expires_in` and calculate absolute expiration time.
2. On every request (easy since this is OWIN middleware), check if the access token is about to expire.
3. If expiring soon, request a new token and construct an identity for it.
4. If an identify already exist (it should), replace its claims from the new identity (with updated access token and expiration).
   - This is where I struggled the most, assuming I could/should replace the whole `ClaimsPrincipal` rather than updating the relevant identity in-place.
5. `SignIn()` with new or updated `ClaimsIdentify`.
