### PR TITLE
Support dynamic EndpointBase

### DIFF
--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationHandler.cs
@@ -115,7 +115,7 @@ namespace Owin.Security.Providers.CanvasLMS
             var state = Options.StateDataFormat.Protect(properties);
 
             var authorizationEndpoint =
-                Options.EndpointBase +
+                Options.EndpointBase(Context) +
                 Options.Endpoints.AuthorizationPath +
                 "?client_id=" + Uri.EscapeDataString(Options.ClientId) +
                 "&response_type=" + Uri.EscapeDataString("code") +
@@ -247,7 +247,7 @@ namespace Owin.Security.Providers.CanvasLMS
             };
 
             // Request the token
-            var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.EndpointBase + Options.Endpoints.TokenPath);
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.EndpointBase(Context) + Options.Endpoints.TokenPath);
             requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Basic",
                 new Base64TextEncoder().Encode(Encoding.ASCII.GetBytes(Options.ClientId + ":" + Options.ClientSecret)));
             requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -267,7 +267,7 @@ namespace Owin.Security.Providers.CanvasLMS
             var expiresIn = (int?)response.expires_in;
 
             // Get the user info
-            var userInfoRequest = new HttpRequestMessage(HttpMethod.Get, Options.EndpointBase + Options.Endpoints.UserPath);
+            var userInfoRequest = new HttpRequestMessage(HttpMethod.Get, Options.EndpointBase(Context) + Options.Endpoints.UserPath);
             userInfoRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             userInfoRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             var userInfoResponse = await _httpClient.SendAsync(userInfoRequest);

--- a/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationOptions.cs
+++ b/src/Owin.Security.Providers.CanvasLMS/CanvasAuthenticationOptions.cs
@@ -80,7 +80,7 @@ namespace Owin.Security.Providers.CanvasLMS
         /// <summary>
         /// Gets the base Canvas endpoint URL
         /// </summary>
-        public string EndpointBase { get; private set; }
+        public Func<IOwinContext, string> EndpointBase { get; private set; }
 
         /// <summary>
         /// Gets the sets of OAuth endpoints used to authenticate against Canvas.
@@ -126,6 +126,17 @@ namespace Owin.Security.Providers.CanvasLMS
         /// </summary>
         /// <param name="endpointBase">The base Canvas endpoint URL, e.g. https://canvas.instructure.com</param>
         public CanvasAuthenticationOptions(string endpointBase)
+            : this(_ => endpointBase)
+        {
+            if (endpointBase == null)
+                throw new ArgumentNullException(nameof(endpointBase));
+        }
+
+        /// <summary>
+        ///     Initializes a new <see cref="CanvasAuthenticationOptions" />
+        /// </summary>
+        /// <param name="endpointBase">Function to generate the base Canvas endpoint URL, e.g. https://canvas.instructure.com</param>
+        public CanvasAuthenticationOptions(Func<IOwinContext, string> endpointBase)
             : base(Constants.DefaultAuthenticationType)
         {
             if (endpointBase == null)


### PR DESCRIPTION
Specifically to support LTI scenarios where multiple instances of Canvas
may need to be supported by the same application. Typically the API domain (received from the LTI `POST` as `custom_canvas_api_domain`) would be retrieved from cookies or session.
